### PR TITLE
convert build method to use pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "MesonPy"
+version = "0.0.1"
+authors = [{name = "Gael Pabois", email = "gael.pabois@gmail.com"}]
+# license="LICENSE"  # no license is specified
+description= "Websocket based python wrapper for Electron projects"
+dependencies = ["websockets", "pyaes", "pbkdf2", "bcrypt", "pycryptodome", "pyscrypt"]
+dynamic = ["readme"]
+
+[project.urls]
+home-page = "https://github.com/Bartpab/meson-py"
+
+[build-system]
+requires = ["setuptools>65.0.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+long_description_content_type = text/markdown
+long_description = file: README.md
+

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,4 @@
-import os
-from setuptools import setup, Command, find_packages
+from setuptools import setup
 
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+setup()
 
-class CleanCommand(Command):
-    """Custom clean command to tidy up the project root."""
-    user_options = []
-    def initialize_options(self):
-        pass
-    def finalize_options(self):
-        pass
-    def run(self):
-        os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
-
-setup(
-	name='MesonPy',
-	version = "0.0.1",
-	author = "Gael Pabois",
-	author_email = "gael.pabois@gmail.com",
-	packages = find_packages(),
-	url="https://github.com/Bartpab/meson-py",
-	license="LICENSE",
-	description="Websocket based python wrapper for Electron projects",
-	long_description=open('README.md').read(),
-	install_requires=required,
-	cmdclass={
-		'clean': CleanCommand,
-	}
-)


### PR DESCRIPTION
This is a minimal change for an attempt to build pandas for Python 3.12.
there is no change to the source code, therefore the version number is unchanged.
Only the metadata specification method is altered.

My build method (in a python 3.12 virtual environment) was:
`pip install build`
`python -m build --no-isolation`
